### PR TITLE
fix: normaliza o line-height entre body e fontes

### DIFF
--- a/_sass/general.scss
+++ b/_sass/general.scss
@@ -10,6 +10,7 @@
 body {
   font-family: "Merriweather", serif;
   font-size: 18px;
+  line-height: 31px;
   font-weight: 400;
   color: $gray-dark;
 }

--- a/_sass/typography.scss
+++ b/_sass/typography.scss
@@ -17,6 +17,7 @@ $font-size-4: 50px;
 
 .font-size-0 {
   font-size: $font-size-0;
+  line-height: 18px;
 }
 
 .font-size-1 {
@@ -25,7 +26,7 @@ $font-size-4: 50px;
 
 .font-size-2 {
   font-size: $font-size-2;
-  line-height: 30px;
+  line-height: 31px;
 }
 
 .font-size-3 {
@@ -89,7 +90,7 @@ p {
   color: $gray-dark;
   font-size: inherit;
   letter-spacing: -0.1px;
-  line-height: 31px;
+  line-height: inherit;
   @extend .margin-top-0;
   @extend .margin-right-0;
   @extend .margin-bottom-3;


### PR DESCRIPTION
Tinha uma diferença bem legal no line-height entre parágrafos e listas (e possivelmente outras coisas).

E agora tudo ficará normalizado, pois começa pelo body.