### PR TITLE
fix: bug estranho na renderização do markdown no Github

### DIFF
--- a/_posts/2015-08-03-engenharia-vs-engenhoca.markdown
+++ b/_posts/2015-08-03-engenharia-vs-engenhoca.markdown
@@ -34,6 +34,7 @@ Não interprete isto como **mandamentos** mas, de todos os projetos que particip
 ## Qual o próximo passo?
 
 Assinar a nossa Newsletter para receber novos posts em primeira mão!
+
 <div class="margin-top--2">
   <a class="button button-border button-medium" href="#newsletter">
     Assine a newsletter


### PR DESCRIPTION
Algo estranho aconteceu, quando o Jekyll renderiza o artigo local,
a seção da Newsletter aparece corretamente, porém na versão em
produção, o HTML desta seção aparece como texto. Vou tentar colocar
um espaço entre o markdown e o HTML.